### PR TITLE
Use correct typed `NA`

### DIFF
--- a/R/data_cleaning.R
+++ b/R/data_cleaning.R
@@ -29,7 +29,7 @@ plr_variable_check <- function(df) {
   time_var <- dplyr::if_else("tmst" %in% names, "tmst", "tutc")
   irrad_var <- dplyr::if_else("poay" %in% names, "poay", "ghir")
   temp_var <- dplyr::if_else("temp" %in% names, "temp", "modt")
-  wind_var <- dplyr::if_else("wspa" %in% names, "wspa", NULL)
+  wind_var <- dplyr::if_else("wspa" %in% names, "wspa", NA_character_)
   final <- data.frame(time_var, power_var, irrad_var, temp_var, wind_var,
                       stringsAsFactors = FALSE)
   if (is.null(final$wind_var)) {


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

`if_else()` now uses vctrs, which generally makes it more permissive when there are varying types, but does require that all inputs are vectors. You were using `NULL` in the `false` slot, which was never intended to be allowed, and is now an error.

In dev dplyr, you could just do `NA` but that won't work with CRAN dplyr.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package in ahead of time! Thanks!